### PR TITLE
Directly install .deb file dependencies to work around bug in Ansible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,10 @@
     - openjdk-8-jdk
     - tint2
     - x11-xkb-utils
+    - libgnutls28
+    - libtasn1-3-bin
+    - libxfont1
+    - libglu1-mesa
 
 - name: update java alternatives
   command: update-java-alternatives -s {{ java_version }}


### PR DESCRIPTION
When .deb file is installed and its dependencies are not yet met, then
Ansible fails with an error as reported here:
https://github.com/ansible/ansible-modules-core/issues/3752
https://github.com/ansible/ansible-modules-core/pull/3816
